### PR TITLE
Configure Gatsby for Netlify adapter

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,6 +9,8 @@
 // Add this to ignore SSL errors for local development
 // process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
 
+const adapter = require("gatsby-adapter-netlify")
+
 // Hard-disable Gatsby Cloud CDNs on Netlify
 if (process.env.NETLIFY) {
   process.env.GATSBY_CLOUD_IMAGE_CDN = "0"
@@ -16,6 +18,7 @@ if (process.env.NETLIFY) {
 }
 
 module.exports = {
+  adapter: adapter(),
   // flags: {
   //   LMDB_STORE: false,
   // },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@wordpress/block-library": "^9.12.0",
     "babel-plugin-styled-components": "^2.1.4",
     "gatsby": "^5.14.6",
+    "gatsby-adapter-netlify": "^1.2.1",
     "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-image": "^3.14.0",
     "gatsby-plugin-manifest": "^5.3.1",


### PR DESCRIPTION
## Summary
- add `gatsby-adapter-netlify` dependency
- initialize Netlify adapter in `gatsby-config.js`

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_b_68a0ed11eb388326a3c0a412f02f9510