### PR TITLE
chore: use Gatsby defaults for Netlify build

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,11 +9,6 @@
 // Add this to ignore SSL errors for local development
 // process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
 
-// Hard-disable Gatsby Cloud CDNs on Netlify
-if (process.env.NETLIFY) {
-  process.env.GATSBY_CLOUD_IMAGE_CDN = "0"
-  process.env.GATSBY_CLOUD_FILE_CDN = "0"
-}
 
 module.exports = {
   // flags: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,4 @@
 [build]
-  command = "GATSBY_CLOUD_IMAGE_CDN=0 GATSBY_CLOUD_FILE_CDN=0 gatsby build"
+  command = "gatsby build"
   publish = "public"
-  environment = { NODE_VERSION = "20", GATSBY_CPU_COUNT = "1" }
-
-[context.production.environment]
-  GATSBY_CLOUD_IMAGE_CDN = "0"
-  GATSBY_CLOUD_FILE_CDN = "0"
-
-[context.deploy-preview.environment]
-  GATSBY_CLOUD_IMAGE_CDN = "0"
-  GATSBY_CLOUD_FILE_CDN = "0"
+  environment = { NODE_VERSION = "18" }


### PR DESCRIPTION
## Summary
- use Node 18 on Netlify
- drop Netlify overrides for Gatsby Cloud CDNs

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_b_68a0eebbfce08326942eff9e373b4458