### PR TITLE
Consolidate webpack config hook into single export

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -221,19 +221,7 @@ async function getProjects({ graphql, reporter }) {
   return published
 }
 
-/* ----------------------------- ISOTOPE WEBPACK ---------------------------- */
-
-exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
-  if (stage === "build-html") {
-    actions.setWebpackConfig({
-      module: {
-        rules: [{ test: /isotope-layout/, use: loaders.null() }],
-      },
-    })
-  }
-}
-
-/* ---------------------------------- deploy troubleshooting ---------------------------------- */
+/* ---------------------- Webpack null loader configuration ---------------------- */
 
 exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
   if (stage === "build-html" || stage === "develop-html") {


### PR DESCRIPTION
## Summary
- merge duplicate `onCreateWebpackConfig` hooks into one conditional function

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_b_68a0ef2026a083268aa654ef31d5a89d