### PR TITLE
chore: reduce wp source concurrency

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,17 +33,19 @@ module.exports = {
           process.env.WPGRAPHQL_URL ||
           `https://studiosc.theremotecreative.com/graphql`,
         schema: {
-          requestConcurrency: 3, // lower = slower but safer for Netlify
+          requestConcurrency: 1, // lower = slower but safer for Netlify
           previewRequestConcurrency: 2,
         },
         type: {
           MediaItem: {
             localFile: {
-              maxFileSizeBytes: 5000000, // Skip images >5MB
-              requestConcurrency: 2,
+              maxFileSizeBytes: 4000000, // Skip images >4MB
+              requestConcurrency: 1,
             },
           },
         },
+        // Reuse previously downloaded media files during builds
+        preserveMediaFiles: true,
       },
     },
 


### PR DESCRIPTION
## Summary
- decrease WordPress source request concurrency and media request concurrency
- skip downloading media files bigger than 4MB
- reuse previously downloaded media files on build via `preserveMediaFiles`

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_b_68a0ef25ec408326aa1c5f1011521691