### PR TITLE
chore: remove gatsby cloud plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -65,7 +65,6 @@ module.exports = {
     `gatsby-plugin-styled-components`,
     `gatsby-plugin-smoothscroll`,
     "gatsby-plugin-netlify",
-    "gatsby-plugin-gatsby-cloud",
     {
       resolve: `gatsby-plugin-manifest`,
       options: {


### PR DESCRIPTION
## Summary
- remove `gatsby-plugin-gatsby-cloud` from plugin list

## Testing
- `npm run build` *(fails: gatsby not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9e922dcc88326b713e591897e4e31