### PR TITLE
chore: clean cache before Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "gatsby build"
+  command = "gatsby clean && gatsby build"
   publish = "public"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- clean Gatsby cache before Netlify builds

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*
- `npx prettier --check netlify.toml --parser toml` *(fails: Couldn't resolve parser "toml")*

------
https://chatgpt.com/codex/tasks/task_b_68afca2c818c832698aedbcb8fc9f444