### PR TITLE
chore(netlify): build from source when no prebuild

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,4 @@
   NODE_VERSION = "18"
   NODE_OPTIONS = "--max_old_space_size=4096"
   GATSBY_CPU_COUNT = "1"
+  NPM_CONFIG_BUILD_FROM_SOURCE = "true"


### PR DESCRIPTION
## Summary
- force npm to build native modules from source on Netlify

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*
- `netlify deploy --prod` *(fails: netlify: command not found; install attempt blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_b_68afd796b18883269a1ec2f6b754c6be