### PR TITLE
chore: adjust Netlify CPU count

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,4 +5,4 @@
 [build.environment]
   NODE_VERSION = "18"
   NODE_OPTIONS = "--max_old_space_size=4096"
-  GATSBY_CPU_COUNT = "1"
+  GATSBY_CPU_COUNT = "4"


### PR DESCRIPTION
## Summary
- increase GATSBY_CPU_COUNT to 4 to better match Netlify cores

## Testing
- `npm test` (fails: Write tests! -> https://gatsby.dev/unit-testing)


------
https://chatgpt.com/codex/tasks/task_b_68b06535051883268143e821a2c275c7